### PR TITLE
Fix HTML tags leaking into constant value Markdown output

### DIFF
--- a/dartdoc_txt/lib/src/element_renderers.dart
+++ b/dartdoc_txt/lib/src/element_renderers.dart
@@ -80,8 +80,8 @@ String renderTopLevelProperties(Library library, Templates templates) {
       return {
         'name': c.name,
         'typeName': plainTypeName(c.modelType),
-        'hasConstantValue': c.constantValue.isNotEmpty,
-        'constantValue': unescapeHtml(c.constantValue),
+        'hasConstantValue': c.constantValueBase.isNotEmpty,
+        'constantValue': unescapeHtml(c.constantValueBase),
         'hasDocumentation': doc.isNotEmpty,
         'documentation': doc,
       };

--- a/dartdoc_txt/test/integration/fixture/basic_library/lib/src/constants.dart
+++ b/dartdoc_txt/test/integration/fixture/basic_library/lib/src/constants.dart
@@ -3,3 +3,15 @@ const String defaultName = 'World';
 
 /// A top-level variable.
 int globalCounter = 0;
+
+/// An immutable 2D point.
+class Point {
+  final int x;
+  final int y;
+
+  /// Creates a point with the given coordinates.
+  const Point(this.x, this.y);
+}
+
+/// The origin point.
+const Point origin = Point(0, 0);

--- a/dartdoc_txt/test/integration/golden/basic_library/INDEX.md.expect
+++ b/dartdoc_txt/test/integration/golden/basic_library/INDEX.md.expect
@@ -11,6 +11,7 @@ the Markdown documentation generator.
 
 ### Classes from basic_library
 
+- [Point](basic_library/Point/Point.md) — An immutable 2D point.
 - [MyClass](basic_library/MyClass/MyClass.md) — A simple class with documentation.
 ### Enums from basic_library
 
@@ -26,5 +27,6 @@ See [top-level-functions.md](basic_library/top-level-functions/top-level-functio
 See [top-level-properties.md](basic_library/top-level-properties/top-level-properties.md) for more details.
 
 - defaultName — A top-level constant.
+- origin — The origin point.
 - globalCounter — A top-level variable.
 

--- a/dartdoc_txt/test/integration/golden/basic_library/basic_library/Point/Point.md.expect
+++ b/dartdoc_txt/test/integration/golden/basic_library/basic_library/Point/Point.md.expect
@@ -1,0 +1,31 @@
+# Point
+
+```dart
+class Point
+```
+
+An immutable 2D point.
+
+## Constructors
+
+### Point.new(int x, int y) const
+
+Creates a point with the given coordinates.
+
+```dart
+const Point(this.x, this.y);
+```
+
+---
+## Properties
+
+### x → int
+
+`final`
+
+---
+### y → int
+
+`final`
+
+---

--- a/dartdoc_txt/test/integration/golden/basic_library/basic_library/top-level-properties/top-level-properties.md.expect
+++ b/dartdoc_txt/test/integration/golden/basic_library/basic_library/top-level-properties/top-level-properties.md.expect
@@ -10,6 +10,14 @@ A top-level constant.
 
 ---
 
+### origin → Point
+
+`Point(0, 0)`
+
+The origin point.
+
+---
+
 ## Properties
 
 ### globalCounter → int


### PR DESCRIPTION
Fix #3.

Dartdoc's `constantValue` getter calls `linkifyConstantValue()` internally, which wraps type references in `<a href="%%__HTMLBASE_dartdoc_internal__%%...">` tags intended for dartdoc's HTML renderer. Since pubdoc emits Markdown, these tags were leaking through verbatim.

The fix is to use `constantValueBase` instead — the pre-linkified, HTML-escaped string — and pass it through the existing `unescapeHtml()` call to get clean plain-text output.

A `Point` class with a const constructor is added to the `basic_library` fixture to cover the type-reference case (i.e. `const Point(0, 0)`), along with updated golden files.

