### PR TITLE
[pubdoc] Support pre-release versions

### DIFF
--- a/pubdoc/PRINCIPLE.md
+++ b/pubdoc/PRINCIPLE.md
@@ -270,32 +270,29 @@ because the workspace projects share the same dependencies, as stated [here][3].
 Pre-release versions are always resolved as if the `exact` strategy were in
 effect, regardless of the configured resolution strategy. That is, `1.0.0-dev.1`
 always resolves to documentation version `1.0.0-dev.1`, never to a shared
-version like `1.0.x` or `1.x`.
+version like `1.0.x` or `1.x`, even if `loose-*` strategies are specified.
 
-This is because the `loose-*` strategies assume that versions sharing the same
-major (or major.minor) number have a compatible public API. This assumption
-holds for stable releases—semver guarantees that patch and minor bumps don't
-break the public API—but it does _not_ hold for pre-release versions. For
-example, `2.0.0-beta.1` may have a significantly different API from `2.0.0`, and
-even `2.0.0-beta.1` and `2.0.0-beta.2` are not guaranteed to be compatible with
-each other. To avoid generating misleading documentation, pubdoc treats each
-pre-release version as a distinct, non-shareable documentation version.
+Quoting the [SemVer specification][4] as to why this is the case:
 
-Note that this rule applies to the documentation version resolution only. The
-rest of the flow—cache lookup, documentation generation, symlink creation—works
-the same way as for stable versions. The cache directory would look like:
+> A pre-release version indicates that the version is unstable and might not
+> satisfy the intended compatibility requirements as denoted by its associated
+> normal version.
+
+Note that this rule applies to documentation version resolution only. The rest
+of the flow—cache lookup, documentation generation, symlink creation—works the
+same way as for stable versions.
+
+The cache directory would look like this:
 
 ```
 ~/.pubdoc/cache/
 `-- firebase_core/
     |-- firebase_core-2.0.0-beta.1/  # pre-release, always exact
     |-- firebase_core-2.0.0-beta.2/  # pre-release, always exact
-    |-- firebase_core-2.0.x/         # stable, loose-patch
+    |-- firebase_core-2.x/           # loose-minor docs, never shared with pre-releases
 ```
 
-Also note that pre-release versions never share documentation with stable
-versions. Even if both `2.0.0-beta.1` and `2.0.0` exist, they are treated as
-completely separate documentation versions.
+[4]: https://semver.org/#spec-item-9
 
 ### When should I run `pubdoc get`?
 

--- a/pubdoc/lib/src/version_resolution.dart
+++ b/pubdoc/lib/src/version_resolution.dart
@@ -15,14 +15,6 @@ enum ResolutionStrategy {
 
 extension VersionDocResolution on Version {
   /// Returns the documentation version string for the given strategy.
-  ///
-  /// - `exact`: `"1.2.3"`
-  /// - `loosePatch`: `"1.2.x"`
-  /// - `looseMinor`: `"1.x"`
-  ///
-  /// Pre-release versions (e.g., `1.0.0-dev.1`) always resolve as exact
-  /// regardless of the strategy, since they have no API compatibility
-  /// guarantees.
   String docVersion(ResolutionStrategy strategy) {
     if (isPreRelease) return toString();
     return switch (strategy) {

--- a/pubdoc/test/integration/get_command_test.dart
+++ b/pubdoc/test/integration/get_command_test.dart
@@ -664,7 +664,6 @@ void main() {
       env.pubGet();
       final result = await command.run(packageNames: ['dio']);
 
-      final cacheDir = '$_cacheDir/dio/dio-1.0.0-dev.1';
       expect(
         result,
         _isGetResult(
@@ -678,6 +677,7 @@ void main() {
           },
         ),
       );
+      final cacheDir = '$_cacheDir/dio/dio-1.0.0-dev.1';
       verify(
         generator.generate(
           sourcePath: anyNamed('sourcePath'),
@@ -685,6 +685,14 @@ void main() {
         ),
       );
       verifyNoMoreInteractions(generator);
+      expect(
+        CacheMetadata.read(cacheDir, fs: env.fs),
+        _isCacheMetadata(
+          pkgName: 'dio',
+          version: '1.0.0-dev.1',
+          pkgVersion: '1.0.0-dev.1',
+        ),
+      );
     });
 
     test('looseMinor with pre-release uses exact version', () async {
@@ -714,10 +722,18 @@ void main() {
         ),
       );
       verifyNoMoreInteractions(generator);
+      expect(
+        CacheMetadata.read(cacheDir, fs: env.fs),
+        _isCacheMetadata(
+          pkgName: 'dio',
+          version: '1.0.0-dev.1',
+          pkgVersion: '1.0.0-dev.1',
+        ),
+      );
     });
 
-    test('pre-release and stable are separate', () async {
-      final command = makeCommand(strategy: .loosePatch);
+    test('never share docs with stable versions', () async {
+      final command = makeCommand(strategy: .looseMinor);
 
       // First: pre-release version
       env.pubspec.addDependency('dio', '1.0.0-dev.1');
@@ -729,57 +745,22 @@ void main() {
       env.pubGet();
       await command.run(packageNames: ['dio']);
 
-      verify(
+      verifyInOrder([
         generator.generate(
           sourcePath: anyNamed('sourcePath'),
           outputDir: '$_cacheDir/dio/dio-1.0.0-dev.1',
         ),
-      );
-      verify(
         generator.generate(
           sourcePath: anyNamed('sourcePath'),
-          outputDir: '$_cacheDir/dio/dio-1.0.x',
+          outputDir: '$_cacheDir/dio/dio-1.x',
         ),
-      );
+      ]);
       verifyNoMoreInteractions(generator);
       expect(
         env.fs.directory('$_cacheDir/dio/dio-1.0.0-dev.1').existsSync(),
         isTrue,
       );
-      expect(env.fs.directory('$_cacheDir/dio/dio-1.0.x').existsSync(), isTrue);
-    });
-
-    test('cache reuse for pre-release', () async {
-      final command = makeCommand(strategy: .loosePatch);
-      env.pubspec.addDependency('dio', '1.0.0-dev.1');
-      env.pubGet();
-
-      // First run
-      await command.run(packageNames: ['dio']);
-      verify(
-        generator.generate(
-          sourcePath: anyNamed('sourcePath'),
-          outputDir: '$_cacheDir/dio/dio-1.0.0-dev.1',
-        ),
-      );
-
-      // Second run — should be a cache hit
-      reset(generator);
-      final result = await command.run(packageNames: ['dio']);
-      verifyNoMoreInteractions(generator);
-      expect(
-        result,
-        _isGetResult(
-          packages: {
-            'dio': _isPackageGetResult(
-              documentation: '$_projectRoot/.pubdoc/dio',
-              version: '1.0.0-dev.1',
-              source: '$_pubCacheBase/dio-1.0.0-dev.1/',
-              cacheStatus: CacheStatus.hit,
-            ),
-          },
-        ),
-      );
+      expect(env.fs.directory('$_cacheDir/dio/dio-1.x').existsSync(), isTrue);
     });
   });
 

--- a/pubdoc/test/unit/cache_test.dart
+++ b/pubdoc/test/unit/cache_test.dart
@@ -154,39 +154,6 @@ void main() {
     });
   });
 
-  group('Pre-release versions', () {
-    test('pre-release version gets its own cache dir', () {
-      final manager = CacheManager(config, env: env);
-      final result = manager.checkCache(
-        packageName: 'dio',
-        packageVersion: Version.parse('1.0.0-dev.1'),
-        strategy: ResolutionStrategy.loosePatch,
-        useCache: true,
-      );
-      expect(result.action, CacheAction.generate);
-      expect(result.docVersion, '1.0.0-dev.1');
-    });
-
-    test('cache reuse works for pre-release versions', () {
-      final manager = CacheManager(config, env: env);
-      final cacheDir = config.packageCacheDir('dio', '1.0.0-dev.1');
-      env.fs.directory(cacheDir).createSync(recursive: true);
-      CacheMetadata(
-        version: '1.0.0-dev.1',
-        packageVersion: '1.0.0-dev.1',
-        source: 'file:///test/source',
-      ).write(cacheDir, fs: env.fs);
-
-      final result = manager.checkCache(
-        packageName: 'dio',
-        packageVersion: Version.parse('1.0.0-dev.1'),
-        strategy: ResolutionStrategy.loosePatch,
-        useCache: true,
-      );
-      expect(result.action, CacheAction.reuse);
-    });
-  });
-
   group('CacheMetadata', () {
     test('round-trips through JSON', () {
       final metadata = CacheMetadata(

--- a/pubdoc/test/unit/version_resolution_test.dart
+++ b/pubdoc/test/unit/version_resolution_test.dart
@@ -4,34 +4,48 @@ import 'package:test/test.dart';
 
 void main() {
   group('Version.docVersion', () {
-    final v = Version.parse('4.5.3');
-
     test('exact returns full version', () {
-      expect(v.docVersion(ResolutionStrategy.exact), '4.5.3');
+      expect(
+        Version.parse('4.5.3').docVersion(ResolutionStrategy.exact),
+        '4.5.3',
+      );
     });
 
     test('loosePatch returns major.minor.x', () {
-      expect(v.docVersion(ResolutionStrategy.loosePatch), '4.5.x');
+      expect(
+        Version.parse('4.5.3').docVersion(ResolutionStrategy.loosePatch),
+        '4.5.x',
+      );
     });
 
     test('looseMinor returns major.x', () {
-      expect(v.docVersion(ResolutionStrategy.looseMinor), '4.x');
+      expect(
+        Version.parse('4.5.3').docVersion(ResolutionStrategy.looseMinor),
+        '4.x',
+      );
     });
   });
 
   group('Pre-release versions', () {
-    final v = Version.parse('1.0.0-dev.1');
-
     test('exact returns full version string', () {
-      expect(v.docVersion(ResolutionStrategy.exact), '1.0.0-dev.1');
+      expect(
+        Version.parse('1.0.0-dev.1').docVersion(ResolutionStrategy.exact),
+        '1.0.0-dev.1',
+      );
     });
 
     test('loosePatch returns full version string', () {
-      expect(v.docVersion(ResolutionStrategy.loosePatch), '1.0.0-dev.1');
+      expect(
+        Version.parse('1.0.0-dev.1').docVersion(ResolutionStrategy.loosePatch),
+        '1.0.0-dev.1',
+      );
     });
 
     test('looseMinor returns full version string', () {
-      expect(v.docVersion(ResolutionStrategy.looseMinor), '1.0.0-dev.1');
+      expect(
+        Version.parse('1.0.0-dev.1').docVersion(ResolutionStrategy.looseMinor),
+        '1.0.0-dev.1',
+      );
     });
   });
 }


### PR DESCRIPTION
Pre-release versions (e.g., 1.0.0-dev.1) are always resolved as exact, regardless of the configured resolution strategy. This is because pre-release versions have no API compatibility guarantees, so sharing documentation between them (or with stable versions) would be misleading.