### PR TITLE
[misc] Update PR title check to support new scope format

### DIFF
--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -8,18 +8,8 @@ jobs:
   pr-title:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - name: Check PR title format
         env:
           TITLE: ${{ github.event.pull_request.title }}
-        run: |
-          pattern='^\[(misc|dartdoc|pubdoc|skill)\] [A-Z]'
-          if echo "$TITLE" | grep -qP "$pattern"; then
-            exit 0
-          fi
-          echo "PR title does not follow the required format."
-          echo "Expected: [<scope>] Sentence case title"
-          echo "Where <scope> is one of: misc, dartdoc, pubdoc, and skill."
-          echo "And the title starts with an uppercase letter."
-          echo ""
-          echo "Got: $TITLE"
-          exit 1
+        run: python3 tool/check_pr_title.py "$TITLE"

--- a/tool/check_pr_title.py
+++ b/tool/check_pr_title.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+import re, sys
+
+SCOPES = {'pub', 'ddb', 'misc', 'skill'}
+
+
+def check(title: str) -> bool:
+    """Check if a PR title follows the required format.
+
+    The title must start with one or more comma-separated scopes in brackets,
+    followed by a space and a sentence-case description. Valid scopes are:
+    pub, ddb, misc, skill. No whitespace is allowed within the bracket section.
+
+    Examples of valid titles:
+        [pub] Add new feature
+        [ddb,pub] Fix cross-references
+
+    Returns True if the title is valid, False otherwise.
+    """
+    # Pattern only matches lowercase letters and commas — whitespace disallowed inherently
+    m = re.match(r'^\[([a-z,]+)\] ([A-Z])', title)
+    if not m:
+        return False
+    scopes = m.group(1).split(',')
+    return all(s in SCOPES for s in scopes)
+
+
+title = sys.argv[1]
+if check(title):
+    sys.exit(0)
+
+valid_scopes = ', '.join(sorted(SCOPES))
+print(f"PR title does not follow the required format.")
+print(f"Expected: [<scope>] Sentence case title")
+print(f"Where <scope> is one or more of: {valid_scopes}, comma-separated.")
+print(f"Example: '[pub] Add feature' or '[ddb,pub] Fix something'")
+print(f"Got: {title}")
+sys.exit(1)

--- a/tool/check_pr_title.py
+++ b/tool/check_pr_title.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import re, sys
 
-SCOPES = {'pub', 'ddb', 'misc', 'skill'}
+SCOPES = {"pub", "ddb", "skill", "misc"}
 
 
 def check(title: str) -> bool:
@@ -9,7 +9,7 @@ def check(title: str) -> bool:
 
     The title must start with one or more comma-separated scopes in brackets,
     followed by a space and a sentence-case description. Valid scopes are:
-    pub, ddb, misc, skill. No whitespace is allowed within the bracket section.
+    pub, ddb, skill, misc. No whitespace is allowed within the bracket section.
 
     Examples of valid titles:
         [pub] Add new feature
@@ -17,11 +17,10 @@ def check(title: str) -> bool:
 
     Returns True if the title is valid, False otherwise.
     """
-    # Pattern only matches lowercase letters and commas — whitespace disallowed inherently
-    m = re.match(r'^\[([a-z,]+)\] ([A-Z])', title)
+    m = re.match(r"^\[([a-z,]+)\] ([A-Z])", title)
     if not m:
         return False
-    scopes = m.group(1).split(',')
+    scopes = m.group(1).split(",")
     return all(s in SCOPES for s in scopes)
 
 
@@ -29,10 +28,10 @@ title = sys.argv[1]
 if check(title):
     sys.exit(0)
 
-valid_scopes = ', '.join(sorted(SCOPES))
-print(f"PR title does not follow the required format.")
-print(f"Expected: [<scope>] Sentence case title")
+valid_scopes = ", ".join(sorted(SCOPES))
+print("PR title does not follow the required format.")
+print("Expected: [<scope>] Sentence case title")
 print(f"Where <scope> is one or more of: {valid_scopes}, comma-separated.")
-print(f"Example: '[pub] Add feature' or '[ddb,pub] Fix something'")
+print("Example: '[pub] Add feature' or '[ddb,pub] Fix something'")
 print(f"Got: {title}")
 sys.exit(1)


### PR DESCRIPTION
The PR title workflow previously used an inline shell regex that matched the old verbose scopes (`pubdoc`, `dartdoc`). This replaces it with a dedicated Python script (`tool/check_pr_title.py`) that supports the new abbreviated scopes (`pub`, `ddb`) and allows multiple comma-separated scopes in the bracket section (e.g. `[ddb,pub]`).